### PR TITLE
Rollback the doc section about the DB_MAX_CONNECTIONS

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,8 @@ This configuration will override whatever is on `env.test`.
 
 Do not store sensible information in the `.env` files.
 
+For free DB that have connection limits like `ElephantSQL` you can provide a `DB_MAX_CONNECTIONS` value on the build variables to avoid getting `too many connections` errors.
+
 ##### Forcing test build to run on PRs
 
 To avoid any PR to be merged without the test build successfully ran, you can configure that on the github repository's branch settings.


### PR DESCRIPTION
In the last rebase I lost this line that has important information about
defining the max number of concurrent connections in the db when running
the integration tests.