### PR TITLE
Fix visit url in the README with swagger docs URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ This is basic Nodejs project starter. Its goal is to offer a simple way to start
 6. run `npm run db:create:all`
 7. run `npm start`
 
-visit `http://localhost:9091/graphql`
+visit `http://localhost:9090/docs`
 
 ## Tests
 


### PR DESCRIPTION
This PR fixes the visit URL in the Readme and replace it with the swagger docs path `/docs`