### PR TITLE
Add trailing commas

### DIFF
--- a/scripts/db/migrationRunner/index.ts
+++ b/scripts/db/migrationRunner/index.ts
@@ -56,7 +56,7 @@ async function cmdStatus(umzug: Umzug) {
   const status = {
     current: current,
     executed: executed.map(m => m.file),
-    pending: pending.map(m => m.file)
+    pending: pending.map(m => m.file),
   };
 
   console.log(JSON.stringify(status, null, 2));
@@ -95,14 +95,14 @@ export enum Command {
   CREATE = 'create',
   PREV = 'prev',
   RESET_PREV = 'reset-prev',
-  RESET_HARD = 'reset-hard'
+  RESET_HARD = 'reset-hard',
 }
 
 export function getMigrationsConfig(type: string) {
   const migrationsPath = path.join(
     __dirname,
     '../../../src/db/migrations/',
-    type
+    type,
   );
 
   loadEnvVars();
@@ -118,16 +118,16 @@ export function getMigrationsConfig(type: string) {
         const downPath = filePath.replace('up', 'down');
         return {
           up: () => database.query(fs.readFileSync(filePath, 'utf-8')),
-          down: () => database.query(fs.readFileSync(downPath, 'utf-8'))
+          down: () => database.query(fs.readFileSync(downPath, 'utf-8')),
         };
-      }
+      },
     },
     storage: 'sequelize',
     storageOptions: {
       database,
       sequelize: database,
-      tableName: `_Migrations${capitalize(type)}`
-    }
+      tableName: `_Migrations${capitalize(type)}`,
+    },
   });
 
   umzug.on('migrating', logUmzugEvent('migrating'));

--- a/scripts/db/setup.ts
+++ b/scripts/db/setup.ts
@@ -7,14 +7,14 @@ import { loadEnvVars } from '@config/initializers/envVars';
 
 const findDatabase = async (pool, databaseName) => {
   return await pool.query(
-    `SELECT datname FROM pg_catalog.pg_database WHERE lower(datname) = lower('${databaseName}');`
+    `SELECT datname FROM pg_catalog.pg_database WHERE lower(datname) = lower('${databaseName}');`,
   );
 };
 
 const getPool = () => {
   return new Pool({
     connectionString: `${getConnURI()}/postgres`,
-    ssl: getDatabaseConfig().ssl
+    ssl: getDatabaseConfig().ssl,
   });
 };
 

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -10,6 +10,6 @@ export function applyConfig() {
 export function getConfig() {
   return {
     database: getDatabaseConfig(),
-    detailedErrorMessage: process.env.DETAILED_ERROR_MESSAGE
+    detailedErrorMessage: process.env.DETAILED_ERROR_MESSAGE,
   };
 }

--- a/src/controllers/PropertyController.ts
+++ b/src/controllers/PropertyController.ts
@@ -6,7 +6,7 @@ import {
   Errors,
   POST,
   PATCH,
-  DELETE
+  DELETE,
 } from 'typescript-rest';
 import { Response, Produces, Tags } from 'typescript-rest-swagger';
 import { NotFoundError } from 'typescript-rest/dist/server/model/errors';
@@ -23,7 +23,7 @@ export class PropertiesController {
    */
   @GET
   @Response<IPropertyRead[]>(200, 'Retrieve a list of properties.', [
-    propertyReadExample
+    propertyReadExample,
   ])
   public async list() {
     return await Property.getAll();
@@ -63,11 +63,11 @@ export class PropertiesController {
   @Response<IPropertyWrite>(
     200,
     'Update the property that was sent',
-    propertyWriteExample
+    propertyWriteExample,
   )
   public async update(
     @PathParam('id') id: number,
-    property: IPropertyWrite
+    property: IPropertyWrite,
   ): Promise<IPropertyWrite | null> {
     const result = await Property.updateOne({ ...property, id });
     if (result) {

--- a/src/controllers/UserController.ts
+++ b/src/controllers/UserController.ts
@@ -6,7 +6,7 @@ import {
   Errors,
   POST,
   PATCH,
-  DELETE
+  DELETE,
 } from 'typescript-rest';
 import { Response, Produces, Tags } from 'typescript-rest-swagger';
 import { NotFoundError } from 'typescript-rest/dist/server/model/errors';
@@ -61,7 +61,7 @@ export class UsersController {
   @Response<IUser>(200, 'Update the user that was sent', userExample)
   public async update(
     @PathParam('id') id: number,
-    user: IUser
+    user: IUser,
   ): Promise<IUser | null> {
     const result = await User.updateOne({ ...user, id });
     if (result) {

--- a/src/controllers/docs/property.ts
+++ b/src/controllers/docs/property.ts
@@ -7,15 +7,15 @@ const basePropertyExample = {
   updatedAt: new Date(),
   name: '5th Avenue',
   minRent: 100.5,
-  maxRent: 10000
+  maxRent: 10000,
 };
 
 export const propertyReadExample: IPropertyRead = {
   ...basePropertyExample,
-  user: baseUserExample
+  user: baseUserExample,
 };
 
 export const propertyWriteExample: IPropertyWrite = {
   ...basePropertyExample,
-  userId: baseUserExample.id!
+  userId: baseUserExample.id!,
 };

--- a/src/controllers/docs/user.ts
+++ b/src/controllers/docs/user.ts
@@ -4,7 +4,7 @@ export const baseUserExample: IUser = {
   id: 1,
   createdAt: new Date(),
   updatedAt: new Date(),
-  name: 'Joe'
+  name: 'Joe',
 };
 export const userExample: IUser = {
   ...baseUserExample,
@@ -14,7 +14,7 @@ export const userExample: IUser = {
       name: '5th Avenue',
       minRent: 1,
       maxRent: 1000,
-      userId: baseUserExample.id!
-    }
-  ]
+      userId: baseUserExample.id!,
+    },
+  ],
 };

--- a/src/db/credentials.ts
+++ b/src/db/credentials.ts
@@ -8,7 +8,7 @@ export function getDatabaseConfig() {
     DB_HOST,
     DB_SQLLOG,
     DB_SSL,
-    DB_MAX_CONNECTIONS
+    DB_MAX_CONNECTIONS,
   } = process.env;
 
   const base = {
@@ -18,20 +18,20 @@ export function getDatabaseConfig() {
     databaseName: DB_DATABASE || 'node_api',
     sqlLog: DB_SQLLOG === 'true',
     ssl: DB_SSL === 'true',
-    maxConnections: DB_MAX_CONNECTIONS ? parseInt(DB_MAX_CONNECTIONS) : 5
+    maxConnections: DB_MAX_CONNECTIONS ? parseInt(DB_MAX_CONNECTIONS) : 5,
   };
 
   const development = {
-    ...base
+    ...base,
   };
 
   const test = {
     ...base,
-    databaseName: DB_DATABASE || `${base.databaseName}_test`
+    databaseName: DB_DATABASE || `${base.databaseName}_test`,
   };
 
   const production = {
-    ...base
+    ...base,
   };
 
   const { NODE_ENV } = process.env;

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -7,12 +7,12 @@ export const database = new Sequelize(getConnURIWithDatabaseName(), {
     max: getConfig().database.maxConnections,
     min: 0,
     acquire: 30000,
-    idle: 10000
+    idle: 10000,
   },
   dialect: 'postgres',
   logging: getConfig().database.sqlLog,
   ssl: getConfig().database.ssl,
   dialectOptions: {
-    ssl: getConfig().database.ssl
-  }
+    ssl: getConfig().database.ssl,
+  },
 });

--- a/src/db/migrations/data/20191021.users.ts
+++ b/src/db/migrations/data/20191021.users.ts
@@ -5,13 +5,13 @@ const defaultUser = 'Codelitt';
 export default {
   up: async function() {
     await User.create({
-      name: defaultUser
+      name: defaultUser,
     });
   },
   down: async function() {
     const user = await User.findOne({
-      where: { name: defaultUser }
+      where: { name: defaultUser },
     });
     await User.deleteOne(user!.id);
-  }
+  },
 };

--- a/src/db/seeds/propertySeed.ts
+++ b/src/db/seeds/propertySeed.ts
@@ -11,7 +11,7 @@ export default async () => {
       name: faker.address.streetName(),
       minRent: faker.random.number(1000),
       maxRent: faker.random.number({ min: 1001, max: 10000 }),
-      user
+      user,
     });
   }
 

--- a/src/db/seeds/usersSeed.ts
+++ b/src/db/seeds/usersSeed.ts
@@ -3,10 +3,10 @@ import { User } from '@models';
 export default async () => {
   console.log('Running user seed');
   await User.create({
-    name: 'Codelitt'
+    name: 'Codelitt',
   });
   await User.create({
-    name: 'Avison Young'
+    name: 'Avison Young',
   });
   console.log('Completed running user seed');
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@ import { getApp } from './server';
 
 export function start() {
   console.log(
-    `Starting server in mode: ${process.env.NODE_ENV || 'development'}`
+    `Starting server in mode: ${process.env.NODE_ENV || 'development'}`,
   );
 
   applyConfig();

--- a/src/models/BaseModel.ts
+++ b/src/models/BaseModel.ts
@@ -5,7 +5,7 @@ abstract class BaseModel extends Model {
     const updateOpts: UpdateOptions = {
       where: { id: instance.id },
       limit: 1,
-      returning: true
+      returning: true,
     };
 
     const result = await (this as any).update(instance, updateOpts);
@@ -18,7 +18,7 @@ abstract class BaseModel extends Model {
   public static async deleteOne(id: number): Promise<number> {
     const deleteOpts: DestroyOptions = {
       where: { id },
-      limit: 1
+      limit: 1,
     };
 
     return (this as any).destroy(deleteOpts);
@@ -26,13 +26,13 @@ abstract class BaseModel extends Model {
 
   public static async get(
     id: number,
-    options?: FindOptions | undefined
+    options?: FindOptions | undefined,
   ): Promise<any | null> {
     return await (this as any).findByPk(id, options || this.getFindOptions());
   }
 
   public static async getAll(
-    options?: FindOptions | undefined
+    options?: FindOptions | undefined,
   ): Promise<any[]> {
     return await (this as any).findAll(options || this.getFindOptions());
   }

--- a/src/models/PropertyModel.ts
+++ b/src/models/PropertyModel.ts
@@ -21,9 +21,9 @@ export class Property extends BaseModel {
       include: [
         {
           model: User,
-          as: 'user'
-        }
-      ]
+          as: 'user',
+        },
+      ],
     };
   }
 }
@@ -33,26 +33,26 @@ Property.init(
     id: {
       type: DataTypes.INTEGER,
       autoIncrement: true,
-      primaryKey: true
+      primaryKey: true,
     },
     name: {
       type: new DataTypes.STRING(128),
-      allowNull: false
+      allowNull: false,
     },
     minRent: {
       type: DataTypes.DECIMAL,
-      allowNull: false
+      allowNull: false,
     },
     maxRent: {
       type: DataTypes.DECIMAL,
-      allowNull: false
+      allowNull: false,
     },
     userId: {
-      type: DataTypes.INTEGER
-    }
+      type: DataTypes.INTEGER,
+    },
   },
   {
     tableName: 'properties',
-    sequelize: database
-  }
+    sequelize: database,
+  },
 );

--- a/src/models/UserModel.ts
+++ b/src/models/UserModel.ts
@@ -16,7 +16,7 @@ export class User extends BaseModel {
 
   public static async findByName(name: string): Promise<User | null> {
     const queryOpts = {
-      where: { name }
+      where: { name },
     };
 
     return User.findOne(queryOpts);
@@ -27,9 +27,9 @@ export class User extends BaseModel {
       include: [
         {
           model: Property,
-          as: 'properties'
-        }
-      ]
+          as: 'properties',
+        },
+      ],
     };
   }
 }
@@ -39,23 +39,23 @@ User.init(
     id: {
       type: DataTypes.INTEGER,
       autoIncrement: true,
-      primaryKey: true
+      primaryKey: true,
     },
     name: {
       type: new DataTypes.STRING(128),
-      allowNull: false
-    }
+      allowNull: false,
+    },
   },
   {
     tableName: 'users',
-    sequelize: database
-  }
+    sequelize: database,
+  },
 );
 
 User.hasMany(Property, {
   as: 'properties',
   foreignKey: { allowNull: false, name: 'userId' },
-  onDelete: 'CASCADE'
+  onDelete: 'CASCADE',
 });
 
 Property.belongsTo(User, { as: 'user', foreignKey: 'userId' });

--- a/src/server/exceptionResolver.ts
+++ b/src/server/exceptionResolver.ts
@@ -7,7 +7,7 @@ export default function exceptionResolver(
   err: any,
   _req: express.Request,
   res: express.Response,
-  next: express.NextFunction
+  next: express.NextFunction,
 ) {
   if (err instanceof Errors.HttpError) {
     if (res.headersSent) {

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -15,8 +15,8 @@ export function getApp() {
   app.use(
     bodyParser.urlencoded({
       extended: SERVER_PARSER_EXTENDED === 'true',
-      limit: SERVER_PARSER_LIMIT || '2mb'
-    })
+      limit: SERVER_PARSER_LIMIT || '2mb',
+    }),
   );
   app.use(cors());
 

--- a/tests/integration/controllers/user.controller.test.ts
+++ b/tests/integration/controllers/user.controller.test.ts
@@ -55,7 +55,7 @@ describe('UsersController', () => {
 
     it('with invalid params it returns 400', async () => {
       const invalidParams = await Factory.build('user', {
-        name: Factory.chance('string', { length: 129 })
+        name: Factory.chance('string', { length: 129 }),
       });
       const { body } = await request(getApp())
         .post('/users')
@@ -86,7 +86,7 @@ describe('UsersController', () => {
     it('with invalid params it returns 400', async () => {
       const user = await Factory.create('user');
       const invalidParams = await Factory.build('user', {
-        name: Factory.chance('string', { length: 129 })
+        name: Factory.chance('string', { length: 129 }),
       });
       const { body } = await request(getApp())
         .patch(`/users/${user!.id}`)

--- a/tests/integration/factory/property.definitions.ts
+++ b/tests/integration/factory/property.definitions.ts
@@ -6,6 +6,6 @@ export default function(factory: any) {
     name: factory.chance('name'),
     minRent: factory.chance('integer', { min: 0, max: 1000 }),
     maxRent: factory.chance('integer', { min: 1001, max: 2000 }),
-    userId: factory.assoc('user', 'id')
+    userId: factory.assoc('user', 'id'),
   });
 }

--- a/tests/integration/factory/user.definitions.ts
+++ b/tests/integration/factory/user.definitions.ts
@@ -3,6 +3,6 @@ import { User } from '@models';
 export default function(factory: any) {
   factory.define('user', User, {
     id: factory.sequence('User.id', (n: number) => n),
-    name: factory.chance('name')
+    name: factory.chance('name'),
   });
 }

--- a/tests/integration/models/property.model.test.ts
+++ b/tests/integration/models/property.model.test.ts
@@ -12,7 +12,7 @@ describe('Property', () => {
       it('creates a property for a specific user', async () => {
         const user = await Factory.create('user');
         const property = await Factory.create('property', {
-          userId: user.id
+          userId: user.id,
         });
         expect(property!.userId).toBe(user.id);
       });

--- a/tests/integration/models/user.model.test.ts
+++ b/tests/integration/models/user.model.test.ts
@@ -13,7 +13,7 @@ describe('User', () => {
     describe('with invalid params', () => {
       it('fails to create a user', async () => {
         const userParams = Factory.build('user', {
-          name: Factory.chance('string', { length: 129 })
+          name: Factory.chance('string', { length: 129 }),
         });
 
         await expect(User.create(userParams)).rejects.toThrowError();
@@ -44,7 +44,7 @@ describe('User', () => {
         const user = await Factory.create('user');
         const updatedUser = await User.updateOne({
           id: user.id,
-          name: Factory.chance('string', { length: 100 })()
+          name: Factory.chance('string', { length: 100 })(),
         });
         expect(updatedUser!.name).not.toEqual(user.name);
       });
@@ -56,7 +56,7 @@ describe('User', () => {
 
         const invalidUser = await Factory.build('user', {
           name: Factory.chance('string', { length: 129 }),
-          id: user.id
+          id: user.id,
         });
         await expect(User.updateOne(invalidUser.get())).rejects.toThrowError();
       });

--- a/tests/integration/setup/clearDB.ts
+++ b/tests/integration/setup/clearDB.ts
@@ -5,8 +5,8 @@ export async function clearDB() {
     Object.values(models).map(model => {
       return model.destroy({
         where: {},
-        force: true
+        force: true,
       });
-    })
+    }),
   );
 }

--- a/tests/unit/config/applyConfig.test.ts
+++ b/tests/unit/config/applyConfig.test.ts
@@ -5,9 +5,9 @@ jest.mock('@config', () => ({
   applyConfig: jest.fn(),
   getConfig: () => ({
     database: {
-      sqlLog: false
-    }
-  })
+      sqlLog: false,
+    },
+  }),
 }));
 
 it('On startup, calls the applyConfig', async () => {

--- a/tests/unit/controllers/user.controller.test.ts
+++ b/tests/unit/controllers/user.controller.test.ts
@@ -7,8 +7,8 @@ describe('UsersController', () => {
     it('returns a list of users', async () => {
       const expetedUsers = [
         {
-          name: 'Gabriel'
-        }
+          name: 'Gabriel',
+        },
       ];
       const mockGetAll = jest.fn();
       mockGetAll.mockReturnValue(expetedUsers);
@@ -27,7 +27,7 @@ describe('UsersController', () => {
     describe('with an existing id', async () => {
       it('returns the user', async () => {
         const expetedUser = {
-          name: 'Gabriel'
+          name: 'Gabriel',
         };
 
         const mockGet = jest.fn();

--- a/tslint.json
+++ b/tslint.json
@@ -10,7 +10,8 @@
         "semi": true,
         "singleQuote": true,
         "tabWidth": 2,
-        "useTabs": false
+        "useTabs": false,
+        "trailingComma": "all"
       }
     ],
     "array-type": [


### PR DESCRIPTION
This PR adds a prettier rule to allow the [trailing comma](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Trailing_commas) on lists.

From a dev perspective, it makes it easier to sort lines without worrying about removing the comma off the last item of the list.
> This makes version-control diffs cleaner and editing code might be less troublesome.

**Please note** the number of files is large because the rule has been applied on the whole project with `npm run lint:fix`