### PR TITLE
Fix lint config for vscode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,4 @@
 {
   "editor.tabSize": 2,
-  "editor.formatOnSave": true
+  "tslint.autoFixOnSave": true
 }


### PR DESCRIPTION
Since prettier has been removed we are using tslint extension for vscode to support formatting on save.