### PR TITLE
Fix search methods overriding sent options

### DIFF
--- a/src/models/BaseModel.ts
+++ b/src/models/BaseModel.ts
@@ -28,13 +28,19 @@ abstract class BaseModel extends Model {
     id: number,
     options?: FindOptions | undefined,
   ): Promise<any | null> {
-    return await (this as any).findByPk(id, options || this.getFindOptions());
+    return (this as any).findByPk(id, {
+      ...this.getFindOptions(),
+      ...(options || {}),
+    });
   }
 
   public static async getAll(
     options?: FindOptions | undefined,
   ): Promise<any[]> {
-    return await (this as any).findAll(options || this.getFindOptions());
+    return (this as any).findAll({
+      ...this.getFindOptions(),
+      ...(options || {}),
+    });
   }
 
   public static getFindOptions(): FindOptions {


### PR DESCRIPTION
Fix search methods overriding sent options so we can pass options to the `getAll` and `get` methods.